### PR TITLE
extralearners instead of learners org, add some refs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Imports:
     paradox,
     praznik,
     precrec,
+    randomForest,
     ranger,
     rchallenge,
     skimr,
@@ -63,7 +64,7 @@ Imports:
     tidyr,
     visNetwork,
     xgboost
-Remotes: 
+Remotes:
     mlr-org/mlr3book,
     mlr-org/mlr3extralearners
 Encoding: UTF-8

--- a/_posts/2020-03-11-basics-german-credit/2020-03-11-mlr3-basics-german-credit.Rmd
+++ b/_posts/2020-03-11-basics-german-credit/2020-03-11-mlr3-basics-german-credit.Rmd
@@ -200,13 +200,13 @@ This means we need to decide which learning algorithms, or `r ref("Learner", tex
 Using prior knowledge (e.g. knowing that it is a classification task or assuming that the classes are linearly separable) one ends up with one or more suitable `Learner`s.
 
 Many learners can be obtained via the `r mlr_pkg("mlr3learners")` package.
-Additionally, many learners are provided via the `mlr3learners` [github organization](https://github.com/mlr3learners).
+Additionally, many learners are provided via the `r mlr_pkg("mlr3extralearners")` package, from GitHub.
 These two resources combined account for a large fraction of standard learning algorithms.
 As `mlr3` usually only wraps learners from packages, it is even easy to create a formal `Learner` by yourself.
 You may find the section about [extending mlr3](https://mlr3book.mlr-org.com/extending.html) in the `r mlr_pkg("mlr3book")` very helpful.
 If you happen to write your own `r ref("Learner")` in `mlr3`, we would be happy if you share it with the `mlr3` community.
 
-All available `Learner`s (i.e. all which you have installed from `mlr3`, `mlr3learners`, the [mlr3learners github organization](https://github.com/mlr3learners/), or self-written ones) are registered in the dictionary `r ref("mlr_learners")`:
+All available `Learner`s (i.e. all which you have installed from `mlr3`, `mlr3learners`, `mlr3extralearners`, or self-written ones) are registered in the dictionary `r ref("mlr_learners")`:
 
 ```{r}
 mlr_learners
@@ -216,7 +216,7 @@ For our problem, a suitable learner could be one of the following:
 Logistic regression, CART, random forest (or many more).
 
 A learner can be initialized with the `r ref("lrn()")` function and the name of the learner, e.g., `lrn("classif.xxx")`.
-Use `?mlr_learners_xxx` to open the help page of a learner named `xxx`, or follow the link on the [rendered overview page](https://mlr3learners.mlr-org.com/reference/index.html).
+Use `?mlr_learners_xxx` to open the help page of a learner named `xxx`.
 
 For example, a logistic regression can be initialized in the following manner (logistic regression uses R's `glm()` function and is provided by the `mlr3learners` package):
 

--- a/_posts/2020-03-18-iris-mlr3-basics/2020-03-18-iris-mlr3-basics.Rmd
+++ b/_posts/2020-03-18-iris-mlr3-basics/2020-03-18-iris-mlr3-basics.Rmd
@@ -21,22 +21,23 @@ knitr::opts_chunk$set(
   R.options = list(width = 80)
 )
 lgr::get_logger("mlr3")$set_threshold("warn")
+library(mlr3book)
 ```
 
 ## Goals and Prerequisites
 
-This use case shows how to use the basic mlr3 package on the iris task, so it's our "Hello World" example.
-It assumes no prior knowledge in ML or mlr3.
+This use case shows how to use the basic `r mlr_pkg("mlr3")` package on the iris `r ref("Task")`, so it's our "Hello World" example.
+It assumes no prior knowledge in ML or `r mlr_pkg("mlr3")`.
 You can find most of the content here also in the [mlr3book](https://mlr3book.mlr-org.com/) in a more detailed way.
 Hence we will not make a lot of general comments, but keep it hands-on and short.
 
 The following operations are shown:
 
-* Creating tasks and learners
+* Creating `r ref("Task", "Tasks")` and `r ref("Learner", "Learners")`
 * Training and predicting
-* Resampling / Cross-validation
-* Installing more learners from mlr3's GitHub learner org
-* Benchmarking, to compare multiple learners
+* `r ref("Resampling")` / `r ref("ResamplingCV", "cross-validation")`
+* Installing more `r ref("Learner", "Learners")`
+* `r ref("benchmark", "Benchmarking")` to compare multiple `Learners`
 
 ## Loading basic packages
 
@@ -86,8 +87,8 @@ print(preds)
 
 ## Evaluation
 
-Let's score our prediction object with some metrics.
-And take a deeper look by inspecting the confusion matrix.
+Let's score our `r ref("Prediction")` object with some metrics.
+And take a deeper look by inspecting the `confusion matrix`.
 
 ```{r}
 head(as.data.table(mlr_measures))
@@ -101,7 +102,7 @@ print(cm)
 
 ## Changing hyperpars
 
-The learner contains information about all parameters that can be configured, including data type, constraints, defaults, etc.
+The `r ref("Learner")` contains information about all parameters that can be configured, including data type, constraints, defaults, etc.
 We can change the hyperparameters either during construction of later through an active binding.
 
 ```{r}
@@ -112,7 +113,7 @@ learner2$param_set$values$minsplit = 50
 
 ## Resampling
 
-Resampling simply repeats the train-predict-score loop and collects all results in a nice `data.table`.
+`r ref("Resampling")` simply repeats the train-predict-score loop and collects all results in a nice `data.table`.
 
 ```{r, size = "tiny"}
 cv10 = rsmp("cv", folds = 10)
@@ -129,22 +130,21 @@ print(cm)
 
 ## Populating the learner dictionary
 
-mlr3learners ships out with a dozen different popular learners.
+`r mlr_pkg("mlr3learners")` ships out with a dozen different popular `r ref("Learner", "Learners")`.
 We can list them from the dictionary.
-If we want more, we can load an extension package from mlr3's
-[learner-org](https://github.com/mlr-org/mlr3learners/wiki) on GitHub.
-Note how after the install the dictionary increases in size.
+If we want more, we can install an extension package, `r mlr_pkg("mlr3extralearners")`, from GitHub.
+Note how after the installation the dictionary increases in size.
 
-```{r}
+```{r, message = FALSE}
 head(as.data.table(mlr_learners)[, c("key", "packages")])
-# remotes::install_github("mlr3learners/mlr3learners.randomforest")
-library(mlr3learners.randomforest)
+# remotes::install_github("mlr-org/mlr3extralearners")
+library(mlr3extralearners)
 print(as.data.table(mlr_learners)[, c("key", "packages")])
 ```
 
 ## Benchmarking multiple learners
 
-The `benchmark()` function can conveniently compare learners on the same dataset(s).
+The `r ref("benchmark")` function can conveniently compare `r ref("Learner", "Learners") on the same dataset(s).
 
 ```{r}
 learners = list(learner1, learner2, lrn("classif.randomForest"))


### PR DESCRIPTION
see https://github.com/mlr-org/mlr3gallery/runs/1337521979

this PR currently only fails because `mlr3extralearners` apparently requires `mlr3proba` >= 0.2.2.9000