### PR TITLE
remove `unnest = x_domain` part

### DIFF
--- a/_posts/2020-03-11-mlr3tuning-tutorial-german-credit/2020-03-11-mlr3tuning_tutorial_german_credit.Rmd
+++ b/_posts/2020-03-11-mlr3tuning-tutorial-german-credit/2020-03-11-mlr3tuning_tutorial_german_credit.Rmd
@@ -247,14 +247,7 @@ tuner_random$optimize(instance_random)
 
 Like before, we can review the `Archive`.
 It includes the points before and after the transformation.
-The archive includes a column for each parameter the `Tuner` sampled on the search space (points before the transformation):
-
-```{r}
-as.data.table(instance_random$archive)
-```
-
-The parameters used by the learner (points after the transformation) are stored in in the `x_domain` column as lists.
-By using `unnest = x_domain`, the list elements are expanded to separate columns:
+The archive includes a column for each parameter the `Tuner` sampled on the search space (values before the transformation) and additional columns with prefix `x_domain_*` that refer to the parameters used by the learner (values after the transformation) :
 
 ```{r}
 as.data.table(instance_random$archive)

--- a/_posts/2020-03-11-mlr3tuning-tutorial-german-credit/2020-03-11-mlr3tuning_tutorial_german_credit.Rmd
+++ b/_posts/2020-03-11-mlr3tuning-tutorial-german-credit/2020-03-11-mlr3tuning_tutorial_german_credit.Rmd
@@ -247,7 +247,7 @@ tuner_random$optimize(instance_random)
 
 Like before, we can review the `Archive`.
 It includes the points before and after the transformation.
-The archive includes a column for each parameter the `Tuner` sampled on the search space (values before the transformation) and additional columns with prefix `x_domain_*` that refer to the parameters used by the learner (values after the transformation) :
+The archive includes a column for each parameter the `Tuner` sampled on the search space (values before the transformation) and additional columns with prefix `x_domain_*` that refer to the parameters used by the learner (values after the transformation):
 
 ```{r}
 as.data.table(instance_random$archive)


### PR DESCRIPTION
- `as.data.table(instance_random$archive)` is shown twice
- tuning archive changed, hence the comment `unnest = x_domain` is not required anymore